### PR TITLE
同意事項を選択していなかった場合のエラー文を上書きする

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,7 +469,10 @@
                                 }
                             ],
                             is_required_all_select: true,
-                            not_include_label_text_in_label_tag:true
+                            not_include_label_text_in_label_tag:true,
+                            err_msg_txt:{
+                                all_select: 'すべての項目に同意してください。'
+                            }
                         }
                     ],
                 }


### PR DESCRIPTION
同意事項をチェックしていなかった場合のエラー文を「すべて選択必須です」から変更しました。
よろしくお願いいたします。